### PR TITLE
doc: bindings-syntax.rst typo

### DIFF
--- a/doc/build/dts/bindings-syntax.rst
+++ b/doc/build/dts/bindings-syntax.rst
@@ -632,7 +632,7 @@ property, like the PWM controllers ``pwm1`` and ``pwm2`` in this example:
    };
 
    pwm2: pwm@deadbeef {
-       compatible = "foo,pwm";
+       compatible = "bar,pwm";
        #pwm-cells = <1>;
    };
 


### PR DESCRIPTION
It looks like this node should match `"bar,pwm"`

> The bindings for compatible "foo,pwm" and "bar,pwm" must give a name to the cells that appear in a PWM specifier using pwm-cells:, like this:

